### PR TITLE
Fix Template initialization and comparison.

### DIFF
--- a/lib/simple_templates/parser.rb
+++ b/lib/simple_templates/parser.rb
@@ -3,9 +3,8 @@ require 'simple_templates/parser/placeholder'
 require 'simple_templates/parser/text'
 
 module SimpleTemplates
-  # Parsing the SimpleTemplate means verifying the *syntax* and *semantics* of
-  # the template. That is, it shouldn't have malformed tags, and all tags should
-  # be in the tag whitelist.
+  # Parsing the SimpleTemplate means verifying that there are no malformed tags,
+  # and all tags are in the tag whitelist.
   class Parser
 
       FRIENDLY_TAG_NAMES = {

--- a/lib/simple_templates/template.rb
+++ b/lib/simple_templates/template.rb
@@ -7,8 +7,8 @@ module SimpleTemplates
 
     attr_reader :ast, :errors, :remaining_tokens
 
-    def initialize(ast, errors = [], remaining_tokens = [])
-      @ast              = ast.clone.freeze if errors.empty?
+    def initialize(ast = [], errors = [], remaining_tokens = [])
+      @ast              = ast.clone.freeze
       @errors           = errors.clone.freeze
       @remaining_tokens = remaining_tokens.clone.freeze
     end
@@ -31,7 +31,9 @@ module SimpleTemplates
     end
 
     def ==(other)
-      ast == other.ast
+      ast == other.ast &&
+        errors == other.errors &&
+        remaining_tokens == other.remaining_tokens
     end
   end
 end

--- a/test/simple_templates/parser_test.rb
+++ b/test/simple_templates/parser_test.rb
@@ -49,81 +49,56 @@ describe SimpleTemplates::Parser do
 
 
     it "returns an error when an opening bracket is found without a closing bracket" do
-      SimpleTemplates.parse('foo < <bar>', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 6, but found a placeholder start token instead.")],
-        []
-      )
+      SimpleTemplates.parse('foo < <bar>', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 6, but found a placeholder start token instead.")
+      ]
     end
 
     it "returns an error when a closing bracket is found before an opening bracket" do
-      SimpleTemplates.parse('foo > <bar>', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new('Encountered unexpected token in stream (placeholder end), but expected to see one of the following types: placeholder start, less than, greater than, text.')],
-        []
-      )
+      SimpleTemplates.parse('foo > <bar>', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new('Encountered unexpected token in stream (placeholder end), but expected to see one of the following types: placeholder start, less than, greater than, text.')
+      ]
     end
 
     it "returns errors about invalid placeholders encountered before a syntactical error" do
-      SimpleTemplates.parse('foo <baz> >', []).must_equal SimpleTemplates::Template.new(
-        nil,
-        [
-          SimpleTemplates::Parser::Error.new('Encountered unexpected token in stream (placeholder end), but expected to see one of the following types: placeholder start, less than, greater than, text.'),
-          SimpleTemplates::Parser::Error.new('Invalid placeholder with contents, \'baz\' found starting at position 4.')
-        ],
-        []
-      )
+      SimpleTemplates.parse('foo <baz> >', []).errors.must_equal [
+        SimpleTemplates::Parser::Error.new('Encountered unexpected token in stream (placeholder end), but expected to see one of the following types: placeholder start, less than, greater than, text.'),
+        SimpleTemplates::Parser::Error.new('Invalid SimpleTemplates::AST::Placeholder with contents, \'baz\' found starting at position 4.')
+      ]
     end
 
     it "returns an error when an invalid placeholder name is found" do
-      SimpleTemplates.parse('foo <baz>', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new("Invalid placeholder with contents, 'baz' found starting at position 4.")],
-        []
-      )
+      SimpleTemplates.parse('foo <baz>', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'baz' found starting at position 4.")]
     end
 
     it "returns an multiple errors when there are multiple invalid placeholders" do
-      SimpleTemplates.parse('foo <baz> <buz>', []).must_equal SimpleTemplates::Template.new(
-        nil,
-        [
-          SimpleTemplates::Parser::Error.new("Invalid placeholder with contents, 'baz' found starting at position 4."),
-          SimpleTemplates::Parser::Error.new("Invalid placeholder with contents, 'buz' found starting at position 10.")
-        ],
-        []
-      )
+      SimpleTemplates.parse('foo <baz> <buz>', []).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'baz' found starting at position 4."),
+        SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'buz' found starting at position 10.")
+      ]
     end
 
     it "returns an error when multiple opening brackets are found" do
-      SimpleTemplates.parse('foo <<baz>', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new("Expected text token at character position 5, but found a placeholder start token instead.")],
-        []
-      )
+      SimpleTemplates.parse('foo <<baz>', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected text token at character position 5, but found a placeholder start token instead.")]
     end
 
     it "returns an error when empty placeholder is found" do
-      SimpleTemplates.parse('foo <>', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new("Expected text token at character position 5, but found a placeholder end token instead.")],
-        []
-      )
+      SimpleTemplates.parse('foo <>', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected text token at character position 5, but found a placeholder end token instead.")]
     end
 
     it "returns an error when a closing tag is expected, but an opening tag is found" do
-      SimpleTemplates.parse('foo <bar<>', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 8, but found a placeholder start token instead.")],
-        []
-      )
+      SimpleTemplates.parse('foo <bar<>', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 8, but found a placeholder start token instead.")
+      ]
     end
 
     it "returns an error when a tag is not closed before the end of the input" do
-      SimpleTemplates.parse('foo <bar', ['bar']).must_equal SimpleTemplates::Template.new(
-        nil,
-        [SimpleTemplates::Parser::Error.new("Expected placeholder end token, but reached end of input.")],
-        []
-      )
+      SimpleTemplates.parse('foo <bar', ['bar']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected placeholder end token, but reached end of input.")
+      ]
     end
   end
 end

--- a/test/simple_templates/template_test.rb
+++ b/test/simple_templates/template_test.rb
@@ -41,4 +41,18 @@ describe SimpleTemplates::Template do
       ).must_equal "foo baz \\"
     end
   end
+
+  describe "#==" do
+    it "compares the ast" do
+      SimpleTemplates::Template.new([:ast_a], [], []).wont_equal SimpleTemplates::Template.new([:ast_b], [], [])
+    end
+
+    it "compares the errors" do
+      SimpleTemplates::Template.new([], [:error_a], []).wont_equal SimpleTemplates::Template.new([], [:error_b], [])
+    end
+
+    it "compares the remaining tokens" do
+      SimpleTemplates::Template.new([], [], [:remaining_tokens_a]).wont_equal SimpleTemplates::Template.new([], [], [:remaining_tokens_b])
+    end
+  end
 end


### PR DESCRIPTION
Previously we didn't add the AST to the Template if errors were
present. This behavior probably wasn't intuitive, so this commit
improves initialization to always add the AST nodes.

Also, fix a bug where comparison of Template succeeded even if error
messages were different. This was because Templates were only compared
based on AST, and not contents of the errors or remaining tokens.

Closes #7.
