### PR TITLE
Add require for unescapes and delimiter

### DIFF
--- a/lib/simple_templates.rb
+++ b/lib/simple_templates.rb
@@ -2,6 +2,8 @@ require "strscan"
 
 require 'simple_templates/lexer'
 require 'simple_templates/parser'
+require 'simple_templates/unescapes'
+require 'simple_templates/delimiter'
 
 module SimpleTemplates
   #

--- a/lib/simple_templates/version.rb
+++ b/lib/simple_templates/version.rb
@@ -1,3 +1,3 @@
 module SimpleTemplates
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Bug fix. simple_templates.rb was missing require statement for unescapes and delimiter
