### PR TITLE
Restrict valid placeholder names

### DIFF
--- a/lib/simple_templates/parser.rb
+++ b/lib/simple_templates/parser.rb
@@ -9,6 +9,7 @@ module SimpleTemplates
 
       FRIENDLY_TAG_NAMES = {
         ph_start:        'placeholder start',
+        ph_name:         'placeholder name',
         ph_end:          'placeholder end',
         quoted_ph_start: 'quoted placeholder start',
         quoted_ph_end:   'quoted placeholder end',

--- a/lib/simple_templates/parser/placeholder.rb
+++ b/lib/simple_templates/parser/placeholder.rb
@@ -8,7 +8,7 @@ module SimpleTemplates
     # Recognizes a set of input tokens as a Placeholder.
     class Placeholder < NodeParser
 
-      EXPECTED_TAG_ORDER = [:ph_start, :text, :ph_end]
+      EXPECTED_TAG_ORDER = [:ph_start, :ph_name, :ph_end]
 
       STARTING_TOKENS = Set[:ph_start]
 

--- a/test/simple_templates/parser_test.rb
+++ b/test/simple_templates/parser_test.rb
@@ -69,7 +69,7 @@ describe SimpleTemplates::Parser do
 
     it "returns an error when an opening bracket is found without a closing bracket" do
       SimpleTemplates.parse('foo < <bar>', ['bar']).errors.must_equal [
-        SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 6, but found a placeholder start token instead.")
+        SimpleTemplates::Parser::Error.new("Expected placeholder name token at character position 5, but found a text token instead.")
       ]
     end
 
@@ -91,6 +91,28 @@ describe SimpleTemplates::Parser do
         SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'baz' found starting at position 4.")]
     end
 
+    it "returns an error when a placeholder with newlines is found" do
+      SimpleTemplates.parse("foo <ba\nr>", ["ba\nr"]).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 7, but found a text token instead.")]
+    end
+
+    it "returns an error when a placeholder with spaces is found" do
+      SimpleTemplates.parse("foo <ba r>", ['ba r']).errors.must_equal [
+        SimpleTemplates::Parser::Error.
+        new("Expected placeholder end token at character position 7, but found a text token instead.")]
+    end
+
+    it "returns an error when a placeholder with tabs is found" do
+      SimpleTemplates.parse("foo <ba\tr>", ["ba\tr"]).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 7, but found a text token instead.")]
+    end
+
+    it "returns an error when a placeholder with other characters is found" do
+      SimpleTemplates.parse("foo <ba-r>", ['ba-r']).errors.must_equal [
+        SimpleTemplates::Parser::Error.new("Expected placeholder end token at character position 7, but found a text token instead.")]
+    end
+
+
     it "returns an multiple errors when there are multiple invalid placeholders" do
       SimpleTemplates.parse('foo <baz> <buz>', []).errors.must_equal [
         SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'baz' found starting at position 4."),
@@ -100,12 +122,12 @@ describe SimpleTemplates::Parser do
 
     it "returns an error when multiple opening brackets are found" do
       SimpleTemplates.parse('foo <<baz>', ['bar']).errors.must_equal [
-        SimpleTemplates::Parser::Error.new("Expected text token at character position 5, but found a placeholder start token instead.")]
+        SimpleTemplates::Parser::Error.new("Expected placeholder name token at character position 5, but found a placeholder start token instead.")]
     end
 
     it "returns an error when empty placeholder is found" do
       SimpleTemplates.parse('foo <>', ['bar']).errors.must_equal [
-        SimpleTemplates::Parser::Error.new("Expected text token at character position 5, but found a placeholder end token instead.")]
+        SimpleTemplates::Parser::Error.new("Expected placeholder name token at character position 5, but found a placeholder end token instead.")]
     end
 
     it "returns an error when a closing tag is expected, but an opening tag is found" do


### PR DESCRIPTION
Previously we accepted all text for placeholder names. Instead, we
want to restrict the valid placeholders that we accept.

This also fixes a bug in parsing that arose when the template
contained a newline character.
