### PR TITLE
Allow underscore inside placeholder name

### DIFF
--- a/lib/simple_templates/lexer.rb
+++ b/lib/simple_templates/lexer.rb
@@ -7,7 +7,7 @@ module SimpleTemplates
   class Lexer
     Token = Struct.new(:type, :content, :pos)
 
-    VALID_PLACEHOLDER = { :ph_name => /[A-Za-z0-9]+/ }.freeze
+    VALID_PLACEHOLDER = { ph_name: /[A-Za-z0-9_]+/ }.freeze
 
     def initialize(delimiter, input)
       @input    = input.clone.freeze

--- a/lib/simple_templates/version.rb
+++ b/lib/simple_templates/version.rb
@@ -1,3 +1,3 @@
 module SimpleTemplates
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end

--- a/test/simple_templates/parser_test.rb
+++ b/test/simple_templates/parser_test.rb
@@ -47,6 +47,15 @@ describe SimpleTemplates::Parser do
       ]
     end
 
+    it "allows templates with placeholders that contain underscores" do
+      pholder = SimpleTemplates::AST::Placeholder.new('some_name', 0, true)
+
+      SimpleTemplates.parse('<some_name> bar', ['some_name']).ast.must_equal [
+        pholder,
+        SimpleTemplates::AST::Text.new(' bar', 11, true)
+      ]
+    end
+
     it "parses other placeholder types by changing the delimiter Struct" do
       pholder = SimpleTemplates::AST::Placeholder.new('foo', 0, true)
 


### PR DESCRIPTION
Placeholder name should be able to contain underscores
