### PR TITLE
Change error messages to be more user friendly

### DIFF
--- a/lib/simple_templates/AST/node.rb
+++ b/lib/simple_templates/AST/node.rb
@@ -17,6 +17,10 @@ module SimpleTemplates
         allowed
       end
 
+      def name
+        self.class.to_s.split('::').last
+      end
+
       # :nocov:
       def render(context)
         raise NotImplementedError

--- a/lib/simple_templates/parser.rb
+++ b/lib/simple_templates/parser.rb
@@ -70,7 +70,7 @@ module SimpleTemplates
 
       def invalid_node_content_errors(ast)
         ast.reject(&:allowed?).map do |node|
-          Error.new("Invalid #{node.class} with contents, '#{node.contents}' " +
+          Error.new("Invalid #{node.name} with contents, '#{node.contents}' " +
           "found starting at position #{node.pos}.")
         end
       end

--- a/lib/simple_templates/version.rb
+++ b/lib/simple_templates/version.rb
@@ -1,3 +1,3 @@
 module SimpleTemplates
-  VERSION = "0.8.5"
+  VERSION = "0.8.6"
 end

--- a/test/simple_templates/parser_test.rb
+++ b/test/simple_templates/parser_test.rb
@@ -29,7 +29,7 @@ describe SimpleTemplates::Parser do
 
       SimpleTemplates.parse('foo <bar>', []).must_equal SimpleTemplates::Template.new(
         [SimpleTemplates::AST::Text.new('foo ', 0, true), pholder],
-        [SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'bar' found starting at position 4.")],
+        [SimpleTemplates::Parser::Error.new("Invalid Placeholder with contents, 'bar' found starting at position 4.")],
         []
       )
     end
@@ -112,14 +112,14 @@ describe SimpleTemplates::Parser do
     it "returns errors about invalid placeholders encountered before a syntactical error" do
       SimpleTemplates.parse('foo <baz> >', []).errors.must_equal [
         SimpleTemplates::Parser::Error.new('Encountered unexpected token in stream (placeholder end), but expected to see one of the following types: placeholder start, quoted placeholder start, quoted placeholder end, text.'),
-        SimpleTemplates::Parser::Error.new('Invalid SimpleTemplates::AST::Placeholder with contents, \'baz\' found starting at position 4.')
+        SimpleTemplates::Parser::Error.new('Invalid Placeholder with contents, \'baz\' found starting at position 4.')
       ]
     end
 
     it "returns an error when an invalid placeholder name is found" do
       SimpleTemplates.parse('foo <baz>', [:bar]).errors.must_equal [
         SimpleTemplates::Parser::Error.
-          new("Invalid SimpleTemplates::AST::Placeholder with contents, 'baz' found starting at position 4.")]
+          new("Invalid Placeholder with contents, 'baz' found starting at position 4.")]
     end
 
     it "returns an error when a placeholder with newlines is found" do
@@ -146,8 +146,8 @@ describe SimpleTemplates::Parser do
 
     it "returns an multiple errors when there are multiple non-whitelisted placeholders" do
       SimpleTemplates.parse('foo <baz> <buz>', []).errors.must_equal [
-        SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'baz' found starting at position 4."),
-        SimpleTemplates::Parser::Error.new("Invalid SimpleTemplates::AST::Placeholder with contents, 'buz' found starting at position 10.")
+        SimpleTemplates::Parser::Error.new("Invalid Placeholder with contents, 'baz' found starting at position 4."),
+        SimpleTemplates::Parser::Error.new("Invalid Placeholder with contents, 'buz' found starting at position 10.")
       ]
     end
 


### PR DESCRIPTION
Now we are showing error messages containing the name of internal classes of simple templates like this:

`Invalid SimpleTemplates::AST::Placeholder with contents, 'make' found starting at position 10.`

We should display something like:

`"Invalid Placeholder with contents, 'make' found starting at position 10."`
