### PR TITLE
Add more descriptive message to missing key exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+cache: bundler
+sudo: false
+rvm:
+   - 2.2.5
+   - 2.3.0

--- a/Rakefile
+++ b/Rakefile
@@ -2,17 +2,6 @@ require "rake/testtask"
 
 task :default => [:test]
 
-begin
-  require "yard"
-  YARD::Rake::YardocTask.new do |t|
-    t.files   = ["lib/**/*.rb"]
-    t.stats_options = ["--list-undoc", "--compact"]
-  end
-
-  task :docs    => [:yard]
-rescue LoadError
-end
-
 Rake::TestTask.new do |t|
   t.verbose = true
   t.libs.push("demo", "test")

--- a/lib/simple_templates/AST/placeholder.rb
+++ b/lib/simple_templates/AST/placeholder.rb
@@ -19,6 +19,8 @@ module SimpleTemplates
         else
           raise 'Unable to render invalid placeholder!'
         end
+      rescue KeyError
+        raise "\"#{contents}\" key missing. Unable to render \"#{contents}\" placeholder"
       end
     end
   end

--- a/lib/simple_templates/AST/placeholder.rb
+++ b/lib/simple_templates/AST/placeholder.rb
@@ -20,8 +20,11 @@ module SimpleTemplates
           raise 'Unable to render invalid placeholder!'
         end
       rescue KeyError
-        raise "\"#{contents}\" key missing. Unable to render \"#{contents}\" placeholder"
+        raise InterpolationError.new(
+          "\"#{contents}\" key missing. Unable to render \"#{contents}\" placeholder.")
       end
     end
+
+    class InterpolationError < RuntimeError; end
   end
 end

--- a/simple_templates.gemspec
+++ b/simple_templates.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.files = `git ls-files`.split("\n")
   s.executables << "simple-template"
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.required_ruby_version = ">= 2.0.0"
-  %w{rake minitest simplecov coveralls guard-minitest yard}.each do |name|
+  %w{rake minitest simplecov coveralls guard-minitest}.each do |name|
     s.add_development_dependency(name)
   end
   s.add_development_dependency("guard", ">=2.12.8", "<3")

--- a/test/simple_templates/AST/placeholder_test.rb
+++ b/test/simple_templates/AST/placeholder_test.rb
@@ -1,28 +1,26 @@
-require_relative "../../test_helper"
+require_relative '../../test_helper'
 
 describe SimpleTemplates::AST::Placeholder do
   let(:target)  {SimpleTemplates::AST::Placeholder}
 
-  describe "render" do
-
+  describe '#render' do
     let(:substitutions) { { my_placeholder: 'result1' } }
 
-    it "fails when the placeholder name is not in the given Hash" do
-      ->(){
+    it 'succeeds' do
+      target.new('my_placeholder', 0, true).
+        render(substitutions).must_equal("result1")
+    end
+
+    it 'fails if the placeholder name is not in the given Hash' do
+      -> {
         target.new('not_in_substitutions', 0, true).render(substitutions)
       }.must_raise SimpleTemplates::AST::InterpolationError
     end
 
-    it "fails when the placeholder is marked as invalid" do
-      ->(){
+    it 'fails if the placeholder is marked as invalid' do
+      -> {
         target.new('my_placeholder', 0, false).render(substitutions)
       }.must_raise RuntimeError
     end
-
-    it "succeeds" do
-      target.new('my_placeholder', 0, true).
-        render(substitutions).must_equal("result1")
-    end
   end
-
 end

--- a/test/simple_templates/AST/placeholder_test.rb
+++ b/test/simple_templates/AST/placeholder_test.rb
@@ -10,7 +10,7 @@ describe SimpleTemplates::AST::Placeholder do
     it "fails when the placeholder name is not in the given Hash" do
       ->(){
         target.new('not_in_substitutions', 0, true).render(substitutions)
-      }.must_raise RuntimeError
+      }.must_raise SimpleTemplates::AST::InterpolationError
     end
 
     it "fails when the placeholder is marked as invalid" do

--- a/test/simple_templates/AST/placeholder_test.rb
+++ b/test/simple_templates/AST/placeholder_test.rb
@@ -10,7 +10,7 @@ describe SimpleTemplates::AST::Placeholder do
     it "fails when the placeholder name is not in the given Hash" do
       ->(){
         target.new('not_in_substitutions', 0, true).render(substitutions)
-      }.must_raise KeyError
+      }.must_raise RuntimeError
     end
 
     it "fails when the placeholder is marked as invalid" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,6 @@ end
 
 Coveralls.noisy = true unless ENV["CI"]
 
-gem "minitest"
 require "minitest/autorun" unless $0=="-e" # skip in guard
 require "minitest/unit"
 


### PR DESCRIPTION
This should take care of #24, adds a descriptive error about a missing key in the hash passed to the render method on a `SimpleTemplates::Template` object.
