### PR TITLE
Add serialization for SimpleTemplates::Template

### DIFF
--- a/lib/simple_templates/AST/node.rb
+++ b/lib/simple_templates/AST/node.rb
@@ -45,6 +45,17 @@ module SimpleTemplates
         self.class.to_s.split('::').last
       end
 
+      # Converts the node to a hash.
+      # @return [Hash]
+      def to_h
+        {
+          contents: contents,
+          pos: pos,
+          allowed: allowed,
+          class: self.class
+        }
+      end
+
       # Not implemented method to render a Node that must be especialized by
       # the class inheriting from this class.
       # @param context [Hash{ Symbol => String }]

--- a/lib/simple_templates/template.rb
+++ b/lib/simple_templates/template.rb
@@ -54,6 +54,16 @@ module SimpleTemplates
       ast.select{ |node| SimpleTemplates::AST::Placeholder === node }.to_set
     end
 
+    # Converts a +SimpleTemplates::Template+ to JSON string.
+    # return [String]
+    def to_json
+      {
+        ast: ast.map(&:to_h),
+        errors: errors.map(&:to_h),
+        remaining_tokens: remaining_tokens.map(&:to_h)
+      }.to_json
+    end
+
     # Compares a +Template+ with another by comparing the +ast+, +errors+
     # and the +remaining_tokens+ of each one
     def ==(other)

--- a/lib/simple_templates/template.rb
+++ b/lib/simple_templates/template.rb
@@ -1,5 +1,4 @@
 require 'set'
-require 'json'
 
 require 'simple_templates/AST/placeholder'
 require 'simple_templates/template_deserializer'
@@ -65,14 +64,14 @@ module SimpleTemplates
       ast.select{ |node| SimpleTemplates::AST::Placeholder === node }.to_set
     end
 
-    # Converts a +SimpleTemplates::Template+ to JSON string.
-    # return [String]
-    def to_json
+    # Converts a +SimpleTemplates::Template+ to Hash.
+    # return [Hash]
+    def to_h
       {
         ast: ast.map(&:to_h),
         errors: errors.map(&:to_h),
         remaining_tokens: remaining_tokens.map(&:to_h)
-      }.to_json
+      }
     end
 
     # Compares a +Template+ with another by comparing the +ast+, +errors+

--- a/lib/simple_templates/template.rb
+++ b/lib/simple_templates/template.rb
@@ -20,7 +20,7 @@ module SimpleTemplates
 
     attr_reader :ast, :errors, :remaining_tokens
 
-    # Creates a new Template form a JSON string
+    # Creates a new Template from a JSON string
     # @return [SimpleTemplates::Template]
     def self.from_json(json)
       deserialized_template = SimpleTemplates::TemplateDeserializer.new(JSON.parse(json))

--- a/lib/simple_templates/template.rb
+++ b/lib/simple_templates/template.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'set'
 
 require 'simple_templates/AST/placeholder'
@@ -72,6 +73,12 @@ module SimpleTemplates
         errors: errors.map(&:to_h),
         remaining_tokens: remaining_tokens.map(&:to_h)
       }
+    end
+
+    # Converts a +SimpleTemplates::Template+ to a JSON string
+    # return [String] The JSON representation for this template
+    def to_json
+      self.to_h.to_json
     end
 
     # Compares a +Template+ with another by comparing the +ast+, +errors+

--- a/lib/simple_templates/template.rb
+++ b/lib/simple_templates/template.rb
@@ -1,6 +1,8 @@
 require 'set'
+require 'json'
 
 require 'simple_templates/AST/placeholder'
+require 'simple_templates/template_deserializer'
 
 module SimpleTemplates
   #
@@ -18,6 +20,15 @@ module SimpleTemplates
   class Template
 
     attr_reader :ast, :errors, :remaining_tokens
+
+    # Creates a new Template form a JSON string
+    # @return [SimpleTemplates::Template]
+    def self.from_json(json)
+      deserialized_template = SimpleTemplates::TemplateDeserializer.new(JSON.parse(json))
+      new(deserialized_template.ast,
+          deserialized_template.errors,
+          deserialized_template.remaining_tokens)
+    end
 
     # Initializes a new Template
     # @param ast <Array[SimpleTemplates::AST::Node]> list of AST nodes

--- a/lib/simple_templates/template_deserializer.rb
+++ b/lib/simple_templates/template_deserializer.rb
@@ -5,21 +5,16 @@ module SimpleTemplates
     end
 
     def ast
-      nodes = []
-      template['ast'].each do |node|
+      template['ast'].map do |node|
         klass = node['class']
-        if valid_ast_class?(klass)
+        if deserializable?(klass)
           ast_class = Object.const_get(klass)
-          nodes << ast_class.new(node['contents'],
-                                 node['pos'],
-                                 node['allowed'])
+          ast_class.new(node['contents'], node['pos'], node['allowed'])
         else
-          raise InvalidClassForDeserializationError.new(
+          raise DeserializationError.new(
             "'#{klass}' is not allowed for deserialization")
         end
       end
-
-      nodes
     end
 
     def errors
@@ -40,13 +35,13 @@ module SimpleTemplates
 
     attr_reader :template
 
-    def valid_ast_class?(ast_class)
-      [
-        "SimpleTemplates::AST::Placeholder",
-        "SimpleTemplates::AST::Text",
-      ].include?(ast_class)
+    def deserializable?(klass)
+      %w[
+        SimpleTemplates::AST::Placeholder
+        SimpleTemplates::AST::Text
+      ].include?(klass)
     end
   end
 
-  class InvalidClassForDeserializationError < RuntimeError; end
+  class DeserializationError < RuntimeError; end
 end

--- a/lib/simple_templates/template_deserializer.rb
+++ b/lib/simple_templates/template_deserializer.rb
@@ -1,0 +1,33 @@
+module SimpleTemplates
+  class TemplateDeserializer
+    def initialize(template)
+      @template = template
+    end
+
+    def ast
+      template['ast'].map do |node|
+        Object.const_get(node['class']).new(node['contents'],
+                                            node['pos'],
+                                            node['allowed'])
+      end
+    end
+
+    def errors
+      template['errors'].map do |error|
+        SimpleTemplates::Parser::Error.new(error['message'])
+      end
+    end
+
+    def remaining_tokens
+      template['remaining_tokens'].map do |remaining_token|
+        SimpleTemplates::Lexer::Token.new(remaining_token['type'],
+                                          remaining_token['content'],
+                                          remaining_token['pos'])
+      end
+    end
+
+    private
+
+    attr_reader :template
+  end
+end

--- a/test/simple_templates/AST/node_test.rb
+++ b/test/simple_templates/AST/node_test.rb
@@ -47,4 +47,15 @@ describe SimpleTemplates::AST::Node do
     end
   end
 
+  describe '#to_h' do
+    it 'converts a node to a hash' do
+      node = SimpleTemplates::AST::TestNodeImpl.new("a", 2, false)
+      node.to_h.must_equal({
+        contents: 'a',
+        pos: 2,
+        allowed: false,
+        class: SimpleTemplates::AST::TestNodeImpl
+      })
+    end
+  end
 end

--- a/test/simple_templates/template_deserializer_test.rb
+++ b/test/simple_templates/template_deserializer_test.rb
@@ -1,13 +1,10 @@
 require_relative "../test_helper"
 
 describe SimpleTemplates::TemplateDeserializer do
-  before do
-    @serialized_template = JSON.parse(
-      SimpleTemplates.parse('Hi <name>', %w[date]).to_h.to_json)
-  end
-
   let(:template) do
-    SimpleTemplates::TemplateDeserializer.new(@serialized_template)
+    serialized_template = JSON.parse(
+      SimpleTemplates.parse('Hi <name>', %w[date]).to_h.to_json)
+    SimpleTemplates::TemplateDeserializer.new(serialized_template)
   end
 
   describe "#ast" do

--- a/test/simple_templates/template_deserializer_test.rb
+++ b/test/simple_templates/template_deserializer_test.rb
@@ -1,0 +1,37 @@
+require_relative "../test_helper"
+
+describe SimpleTemplates::TemplateDeserializer do
+  before do
+    @serialized_template = JSON.parse(
+      SimpleTemplates.parse('Hi <name>', %w[date]).to_json)
+  end
+
+  let(:template) { SimpleTemplates::TemplateDeserializer.new(@serialized_template) }
+
+  describe "#ast" do
+    it 'creates an array of text or placeholders' do
+      template.ast.map(&:class).must_equal [
+        SimpleTemplates::AST::Text,
+        SimpleTemplates::AST::Placeholder
+      ]
+
+      template.ast.map(&:contents).must_equal ["Hi ", "name"]
+    end
+  end
+
+  describe "#errors" do
+    it 'creates an array of errors' do
+      template.errors.map(&:class).must_equal [
+        SimpleTemplates::Parser::Error
+      ]
+
+      template.errors.map(&:message).must_equal [
+        "Invalid Placeholder with contents, 'name' found starting at position 3."
+      ]
+    end
+  end
+
+  describe "#remaining_tokens" do
+    it 'creates an array of remaining tokens'
+  end
+end

--- a/test/simple_templates/template_deserializer_test.rb
+++ b/test/simple_templates/template_deserializer_test.rb
@@ -35,7 +35,7 @@ describe SimpleTemplates::TemplateDeserializer do
 
       -> {
         bad_template.ast
-      }.must_raise SimpleTemplates::InvalidClassForDeserializationError
+      }.must_raise SimpleTemplates::DeserializationError
     end
   end
 

--- a/test/simple_templates/template_deserializer_test.rb
+++ b/test/simple_templates/template_deserializer_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 describe SimpleTemplates::TemplateDeserializer do
   before do
     @serialized_template = JSON.parse(
-      SimpleTemplates.parse('Hi <name>', %w[date]).to_json)
+      SimpleTemplates.parse('Hi <name>', %w[date]).to_h.to_json)
   end
 
   let(:template) { SimpleTemplates::TemplateDeserializer.new(@serialized_template) }

--- a/test/simple_templates/template_test.rb
+++ b/test/simple_templates/template_test.rb
@@ -42,6 +42,38 @@ describe SimpleTemplates::Template do
     end
   end
 
+  describe '#to_json' do
+    it 'serializes a template to a JSON string' do
+      template_as_json = %(
+        {
+           "ast":[
+              {
+                 "contents":"Hi ",
+                 "pos":0,
+                 "allowed":true,
+                 "class":"SimpleTemplates::AST::Text"
+              },
+              {
+                 "contents":"name",
+                 "pos":3,
+                 "allowed":false,
+                 "class":"SimpleTemplates::AST::Placeholder"
+              }
+           ],
+           "errors":[
+              {
+                 "message":"Invalid Placeholder with contents, 'name' found starting at position 3."
+              }
+           ],
+           "remaining_tokens":[]
+        }
+      )
+
+      template = SimpleTemplates.parse('Hi <name>', %w[date])
+      JSON.parse(template.to_json).must_equal(JSON.parse(template_as_json))
+    end
+  end
+
   describe "#==" do
     it "compares the ast" do
       SimpleTemplates::Template.new([:ast_a], [], []).wont_equal SimpleTemplates::Template.new([:ast_b], [], [])

--- a/test/simple_templates/template_test.rb
+++ b/test/simple_templates/template_test.rb
@@ -74,6 +74,14 @@ describe SimpleTemplates::Template do
     end
   end
 
+  describe '.from_json' do
+    it 'deserializes a template from a JSON string' do
+      template = SimpleTemplates.parse('Hi <name>', %w[date])
+      template_as_json = template.to_json
+      template.must_equal(SimpleTemplates::Template.from_json(template_as_json))
+    end
+  end
+
   describe "#==" do
     it "compares the ast" do
       SimpleTemplates::Template.new([:ast_a], [], []).wont_equal SimpleTemplates::Template.new([:ast_b], [], [])

--- a/test/simple_templates/template_test.rb
+++ b/test/simple_templates/template_test.rb
@@ -42,9 +42,9 @@ describe SimpleTemplates::Template do
     end
   end
 
-  describe '#to_h' do
+  describe '#to_json' do
     it 'serializes a template to a JSON string' do
-      template_as_hash = {
+      template_as_json = {
         ast: [{
           contents: "Hi ",
           pos: 0,
@@ -61,10 +61,10 @@ describe SimpleTemplates::Template do
           message: "Invalid Placeholder with contents, 'name' found starting at position 3."
         }],
         remaining_tokens: []
-      }
+      }.to_json
 
       template = SimpleTemplates.parse('Hi <name>', %w[date])
-      template.to_h.must_equal(template_as_hash)
+      template.to_json.must_equal(template_as_json)
     end
   end
 

--- a/test/simple_templates/template_test.rb
+++ b/test/simple_templates/template_test.rb
@@ -42,42 +42,36 @@ describe SimpleTemplates::Template do
     end
   end
 
-  describe '#to_json' do
+  describe '#to_h' do
     it 'serializes a template to a JSON string' do
-      template_as_json = %(
+      template_as_hash = {
+        ast: [{
+          contents: "Hi ",
+          pos: 0,
+          allowed: true,
+          class: SimpleTemplates::AST::Text
+        },
         {
-           "ast":[
-              {
-                 "contents":"Hi ",
-                 "pos":0,
-                 "allowed":true,
-                 "class":"SimpleTemplates::AST::Text"
-              },
-              {
-                 "contents":"name",
-                 "pos":3,
-                 "allowed":false,
-                 "class":"SimpleTemplates::AST::Placeholder"
-              }
-           ],
-           "errors":[
-              {
-                 "message":"Invalid Placeholder with contents, 'name' found starting at position 3."
-              }
-           ],
-           "remaining_tokens":[]
-        }
-      )
+          contents: "name",
+          pos: 3,
+          allowed: false,
+          class: SimpleTemplates::AST::Placeholder
+        }],
+        errors: [{
+          message: "Invalid Placeholder with contents, 'name' found starting at position 3."
+        }],
+        remaining_tokens: []
+      }
 
       template = SimpleTemplates.parse('Hi <name>', %w[date])
-      JSON.parse(template.to_json).must_equal(JSON.parse(template_as_json))
+      template.to_h.must_equal(template_as_hash)
     end
   end
 
   describe '.from_json' do
     it 'deserializes a template from a JSON string' do
       template = SimpleTemplates.parse('Hi <name>', %w[date])
-      template_as_json = template.to_json
+      template_as_json = JSON.dump(template.to_h)
       template.must_equal(SimpleTemplates::Template.from_json(template_as_json))
     end
   end


### PR DESCRIPTION
The changes introduced in this pull request add the ability to serialize an instance of  `SimpleTemplates::Template` to a JSON string. It also works the other way around, creating a `SimpleTemplates::Template` from a JSON string, e.g.:

To serialize:

```ruby
template = SimpleTemplates.parse("Hi <name>", %w[name])
template.to_json
# => "{\"ast\":[{\"contents\":\"Hi \",\"pos\":0,\"allowed\":true,\"class\":\"SimpleTemplates::AST::Text\"},{\"contents\":\"name\",\"pos\":3,\"allowed\":true,\"class\":\"SimpleTemplates::AST::Placeholder\"}],\"errors\":[],\"remaining_tokens\":[]}"
```

To deserialize:

```ruby
SimpleTemplates::Template.from_json(template.to_json)
# => #<SimpleTemplates::Template:0x007fad96056ae0 @ast=[#<SimpleTemplates::AST::Text:0x007fad96056b80 @contents="Hi ", @pos=0, @allowed=true>, #<SimpleTemplates::AST::Placeholder:0x007fad96056b58 @contents="name", @pos=3, @allowed=true>], @errors=[], @remaining_tokens=[]>
```