### PR TITLE
Remove unused variables

### DIFF
--- a/lib/simple_templates/parser/placeholder.rb
+++ b/lib/simple_templates/parser/placeholder.rb
@@ -45,7 +45,7 @@ module SimpleTemplates
       def check_placeholder_syntax
         expected_order_with_found_tokens = EXPECTED_TAG_ORDER.zip(tag_tokens)
 
-        errors = expected_order_with_found_tokens.
+        expected_order_with_found_tokens.
                    reduce([]) do |errs, (expected_type, found_tag)|
 
           if found_tag.nil?

--- a/test/simple_templates/parser_test.rb
+++ b/test/simple_templates/parser_test.rb
@@ -90,7 +90,7 @@ describe SimpleTemplates::Parser do
 
       delim = SimpleTemplates::Delimiter.new(/\\\[\\\[/, /\\\]\\\]/, /\[\[/, /\]\]/)
 
-      ast, errors, remaining_tokens =
+      ast, _, _ =
       SimpleTemplates::Template.new(
         *SimpleTemplates::Parser.new(
           SimpleTemplates::Unescapes.new('[[', ']]'),


### PR DESCRIPTION
This pull request removes the unused variables detected when running the test suite.

```
/Users/acamino/.rvm/rubies/ruby-2.3.0/bin/ruby -w -I"lib:demo:test" -I"/Users/acamino/.rvm/gems/ruby-2.3.0@simple-templates/gems/rake-11.3.0/lib" "/Users/acamino/.rvm/gems/ruby-2.3.0@simple-templates/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "test/**/*_test.rb"
/Users/acamino/repositories/oss/simple_templates/lib/simple_templates/parser/placeholder.rb:48: warning: assigned but unused variable - errors
/Users/acamino/repositories/oss/simple_templates/test/simple_templates/parser_test.rb:93: warning: assigned but unused variable - errors
/Users/acamino/repositories/oss/simple_templates/test/simple_templates/parser_test.rb:93: warning: assigned but unused variable - remaining_tokens
Run options: --seed 39384
```